### PR TITLE
Add Linux/Rider instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ public class ReloadableAttribute : Attribute { }
 
 # How to use
 
+### Windows
+
 First, install Unity Doorstop by downloading their latest release and put the file `winhttp.dll` and `doorstop_config.ini` in the root directory of RimWorld. The default location of the directory is usually `C:\Program Files (x86)\Steam\steamapps\common\RimWorld`.
 
 Next, compile this project or download the release to get `Doorstop.dll` which you put into the games root directly.
@@ -66,5 +68,29 @@ Now start the game, then use [dnSpy](https://github.com/dnSpyEx/dnSpy) and open 
 You can also use Visual Studio but you won't be able to set breakpoints in RimWorld code. 
 
 Finally, attach to the Unity debugger that runs inside RimWorld (use localhost or 127.0.0.1 and the port you configured in the .ini file) and you should be able to set breakpoints in RimWorld code and in your mod code too.
+
+Any change to a dll inside Mods will create copies of that file and they will be patched in to replace the current version. That only happens for methods that are annotated with some attribute named `[Reloadable]` so make sure you deployed that before you start the game.
+
+### Linux (Ubuntu based) with Rider
+
+Download the latest Linux [Unity Doorstop](https://github.com/NeighTools/UnityDoorstop/releases) Release. Make sure you grab a numbered version and not the CI Build.
+Extract `/x64/libdoorstop.so` and `/x64/run.sh` into the root directory of RimWorld. The default location of the directory is usually `~/.steam/debian-installation/steamapps/common/RimWorld/`.
+
+Next, compile this project or download the release to get `Doorstop.dll` which you put into the games root directly.
+
+Finally, you need to adjust the `run.sh` file a bit. Adjust the following lines to look like what I have below.
+```
+executable_name="RimWorldLinux"
+debug_enable="1"
+debug_address="127.0.0.1:50000"
+debug_suspend="1"
+```
+
+Important: Make sure you compile your mod in `Debug` mode so you get `ModName.dll` and `ModName.pdb` into the Mod folder (and please don't release your mod like this!). I typically just create symbolic links to my bin/debug folder, but you can do what you like.
+
+Now start the game by running `run.sh` and then use the Run Config "Attach To Unity Player" in [Rider](https://www.jetbrains.com/rider/) with Host `127.0.0.1` on Port `50000`.
+The `debug_suspend="1"` option makes it wait until your debugger is attached to start the game, so don't panic when you don't see the game start immediately.
+
+You can now put break points in your code in Rider. You can't set breakpoints RimWorld code.
 
 Any change to a dll inside Mods will create copies of that file and they will be patched in to replace the current version. That only happens for methods that are annotated with some attribute named `[Reloadable]` so make sure you deployed that before you start the game.


### PR DESCRIPTION
Add instructions for Linux/Rider to the README.md.
The process is similar in Linux but different enough to cause some confusion. I got things working with some additional trial and error. These instructions should help future Linux users.